### PR TITLE
Simplify `normalizeDate` and fix timezone discard

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -990,10 +990,9 @@
                 for (var i = 0; i < date.length; i++) {
                   date[i] = getDateString(new Date(date[i]));
                 }
-                if (mode == 'range') {
-                  // for range mode, create the other end of the range
-                  if(date.length == 1) date.push(getDateString(new Date(date[0])));
-                  date[1] = getDateString(new Date(date[1]));
+                // for range mode, create the other end of the range if missing
+                if (mode == 'range' && date.length === 1) {
+                  date.push(date[0]);
                 }
               }
             } else {


### PR DESCRIPTION
For no apparent reason, on this conditional branch, `normalizeDate` was
taking `date[1]`, already a `String` (say `"2015-03-31"`) and calling:

``` javascript
getDateString(new Date(date[1]))
```

What happened then is:

``` javascript
new Date(date[1])
// in our case => Mon Mar 30 2015 21:00:00 GMT-0300 (BRT)
```

This is because `new Date(str)` when the `str` has no timezone info will
compensate back to the user's timezone. The function assumes the string
is on `GMT+-0`.

The call to `getDateString(new Date(date[1]))` then returns one day
previous to what it should (say `"2015-03-30"`).

This causes date ranges to be wrong on the west hemisphere. On the east
hemisphere, the problem doesn't happen, because it'll compensate
forwards (to say `Tue Mar 31 2015 03:00:00 GMT+0300 (...)`).
